### PR TITLE
Fix buoy label typo in currents card

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@
                     <h3>Currents</h3>
                     <div class="card-content">
                         <div>
-                            <span class="tide-label">J-Bouy</span>
+                            <span class="tide-label">J-Buoy</span>
                             <div class="text-large font-bold" style="display: flex; gap: 10px; justify-content: center;">
                                 <div id="race-current-speed">Coming Soon :)</div>
                                 <div id="race-current-direction"></div>


### PR DESCRIPTION
## Summary
- fix spelling of J-Buoy label in the Currents card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b31ea73c83329f31a7247ec05772