### PR TITLE
Add timestamp footer for flood warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,6 +626,11 @@
                     <div id="flood-details" style="margin-top: 5px; font-size: 0.9em; padding: 8px;">
                         Loading flood data...
                     </div>
+                    <div style="font-size: 0.7em; color: #888888; margin-top: 15px; border-top: 1px solid #334455; padding-top: 15px;">
+                        Source: BC River Forecast Centre
+                        <br>
+                        Last updated: <span id="flood-timestamp">Loading...</span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1676,7 +1681,10 @@
                 }
 
                 // Update timestamp
-                document.getElementById('flood-timestamp').textContent = currentTime;
+                const timestampEl = document.getElementById('flood-timestamp');
+                if (timestampEl) {
+                    timestampEl.textContent = currentTime;
+                }
 
             } catch (error) {
                 console.error('Error fetching flood warnings:', error);
@@ -1685,7 +1693,10 @@
                         Error loading flood warnings. Please try again later.
                     </div>
                 `;
-                document.getElementById('flood-timestamp').textContent = 'Error loading data';
+                const timestampElErr = document.getElementById('flood-timestamp');
+                if (timestampElErr) {
+                    timestampElErr.textContent = 'Error loading data';
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add info footer to Flood Warnings card
- guard against missing timestamp element in `updateFloodWarnings`

## Testing
- `python3 -m py_compile fetch_carmanah_latest.py`


------
https://chatgpt.com/codex/tasks/task_e_684998f964bc8332b9cec2ef7c19d32f